### PR TITLE
Support installation with Lazy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,7 @@ dependencies = [
  "git-url-parse",
  "git2",
  "nvim-oxi",
+ "serde",
  "thiserror 2.0.10",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 git-url-parse = "0.4.5"
 git2 = "0.19.0"
 nvim-oxi = { version = "0.5.1", features = ["neovim-0-9", "neovim-0-10"] }
+serde = "1.0.217"
 thiserror = "2.0.10"
 
 [lib]


### PR DESCRIPTION
The following changes are thus introduced:

- The output artifact is put in `lua/` instead of the project root
- A dumb `setup` function is added to the plugin

We are one step closer to #1.